### PR TITLE
Added an easy way to add captcha to any form

### DIFF
--- a/Config/config.xml
+++ b/Config/config.xml
@@ -25,6 +25,12 @@
             <tag name="kernel.event_subscriber" />
             <argument type="service" id="request"/>
         </service>
+
+        <service id="thelia.form_validator" class="ReCaptcha\FormValidator\ReCaptchaFormValidator">
+            <argument type="service" id="event_dispatcher" />
+            <argument type="service" id="thelia.translator" />
+            <argument>%kernel.environment%</argument>
+        </service>
     </services>
 
     <hooks>

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <authors>
         <author>
             <name>Vincent Lopes-Vicente</name>

--- a/FormValidator/ReCaptchaFormValidator.php
+++ b/FormValidator/ReCaptchaFormValidator.php
@@ -1,0 +1,52 @@
+<?php
+/*************************************************************************************/
+/*      Copyright (c) Franck Allimant, CQFDev                                        */
+/*      email : thelia@cqfdev.fr                                                     */
+/*      web : http://www.cqfdev.fr                                                   */
+/*                                                                                   */
+/*      For the full copyright and license information, please view the LICENSE      */
+/*      file that was distributed with this source code.                             */
+/*************************************************************************************/
+
+/**
+ * Created by Franck Allimant, CQFDev <franck@cqfdev.fr>
+ * Date: 11/12/2019 15:51
+ */
+
+namespace ReCaptcha\FormValidator;
+
+use ReCaptcha\Event\ReCaptchaCheckEvent;
+use ReCaptcha\Event\ReCaptchaEvents;
+use ReCaptcha\ReCaptcha;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\Translation\TranslatorInterface;
+use Thelia\Core\Form\TheliaFormValidator;
+use Thelia\Form\BaseForm;
+use Thelia\Form\Exception\FormValidationException;
+
+class ReCaptchaFormValidator extends TheliaFormValidator
+{
+    /** @var EventDispatcherInterface */
+    protected $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher, TranslatorInterface $translator, $environment)
+    {
+        $this->dispatcher = $dispatcher;
+
+        parent::__construct($translator, $environment);
+    }
+
+    public function validateForm(BaseForm $aBaseForm, $expectedMethod = null)
+    {
+        // Validate Captcha
+        $checkCaptchaEvent = new ReCaptchaCheckEvent();
+
+        $this->dispatcher->dispatch(ReCaptchaEvents::CHECK_CAPTCHA_EVENT, $checkCaptchaEvent);
+
+        if (! $checkCaptchaEvent->isHuman()) {
+            throw new FormValidationException($this->translator->trans("Sorry, it seems that you're not human.", [], ReCaptcha::DOMAIN_NAME));
+        }
+
+        parent::validateForm($aBaseForm, $expectedMethod);
+    }
+}

--- a/FormValidator/ReCaptchaFormValidator.php
+++ b/FormValidator/ReCaptchaFormValidator.php
@@ -47,6 +47,6 @@ class ReCaptchaFormValidator extends TheliaFormValidator
             throw new FormValidationException($this->translator->trans("Sorry, it seems that you're not human.", [], ReCaptcha::DOMAIN_NAME));
         }
 
-        parent::validateForm($aBaseForm, $expectedMethod);
+        return parent::validateForm($aBaseForm, $expectedMethod);
     }
 }

--- a/I18n/fr_FR.php
+++ b/I18n/fr_FR.php
@@ -4,5 +4,5 @@ return array(
     'Error' => 'Erreur',
     'Secret key' => 'Clé secrète',
     'Site key' => 'Clé du site',
-    'Sorry, it seems that you\'re not human.' => 'Désolé, il semblerait que vous ne siyez pas un être humain.'
+    'Sorry, it seems that you\'re not human.' => 'Désolé, il semblerait que vous ne soyez pas un être humain.'
 );

--- a/I18n/fr_FR.php
+++ b/I18n/fr_FR.php
@@ -4,4 +4,5 @@ return array(
     'Error' => 'Erreur',
     'Secret key' => 'Clé secrète',
     'Site key' => 'Clé du site',
+    'Sorry, it seems that you\'re not human.' => 'Désolé, il semblerait que vous ne siyez pas un être humain.'
 );


### PR DESCRIPTION
This PR adds a specific form validator to the module , which extends the base TheliaFormValidator: `ReCaptchaFormValidator`. 
This form validator dispatches the `CHECK_CAPTCHA_EVENT` event if the `g-recaptcha-response` form field is defined in the request, and throw an exception if a suspicious action is detected.

Thus, adding `{hook name="recaptcha.check"}` to any form will add a ReCaptcha check to this form without the need to update the form validation code.