### PR TITLE
fix: use cURL instead of file_get_contents for siteverify

### DIFF
--- a/Action/ReCaptchaAction.php
+++ b/Action/ReCaptchaAction.php
@@ -52,11 +52,22 @@ class ReCaptchaAction implements EventSubscriberInterface
 
         $requestUrl .= "&remoteip=$remoteIp";
 
-        $result = json_decode(file_get_contents($requestUrl), true);
-        if ($result['success'] == true && (!array_key_exists('score', $result) || $result['score'] > $minScore)) {
-            $event->setHuman(true);
-            $this->captchaVerified = true;
-            return;
+        $curl = curl_init($requestUrl);
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 3);
+        curl_setopt($curl, CURLOPT_TIMEOUT, 5);
+        $response = curl_exec($curl);
+        curl_close($curl);
+
+        if (is_string($response)) {
+            $result = json_decode($response, true);
+            if (is_array($result)
+                && ($result['success'] ?? false) === true
+                && (!array_key_exists('score', $result) || $result['score'] > $minScore)) {
+                $event->setHuman(true);
+                $this->captchaVerified = true;
+                return;
+            }
         }
 
         $this->captchaVerified = false;

--- a/Action/ReCaptchaAction.php
+++ b/Action/ReCaptchaAction.php
@@ -32,30 +32,37 @@ class ReCaptchaAction implements EventSubscriberInterface
             $event->setHuman($this->captchaVerified);
             return;
         }
-        $requestUrl = "https://www.google.com/recaptcha/api/siteverify";
+
+        if (!function_exists('curl_init')) {
+            $this->captchaVerified = false;
+            return;
+        }
 
         $secretKey = ReCaptcha::getConfigValue('secret_key');
         $minScore = ReCaptcha::getConfigValue('min_score', 0.3);
-        $requestUrl .= "?secret=$secretKey";
 
         $captchaResponse = $event->getCaptchaResponse();
         if (null == $captchaResponse && $this->request) {
             $captchaResponse = $this->request->request->get('g-recaptcha-response');
         }
 
-        $requestUrl .= "&response=$captchaResponse";
-
         $remoteIp = $event->getRemoteIp();
         if (null == $remoteIp && $this->request) {
             $remoteIp = $this->request->server->get('REMOTE_ADDR');
         }
 
-        $requestUrl .= "&remoteip=$remoteIp";
+        $payload = http_build_query([
+            'secret' => (string) $secretKey,
+            'response' => (string) $captchaResponse,
+            'remoteip' => (string) $remoteIp,
+        ]);
 
-        $curl = curl_init($requestUrl);
+        $curl = curl_init('https://www.google.com/recaptcha/api/siteverify');
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, 3);
         curl_setopt($curl, CURLOPT_TIMEOUT, 5);
+        curl_setopt($curl, CURLOPT_POST, true);
+        curl_setopt($curl, CURLOPT_POSTFIELDS, $payload);
         $response = curl_exec($curl);
         curl_close($curl);
 

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -20,7 +20,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>4.0.3</version>
+    <version>4.0.4</version>
     <authors>
         <author>
             <name>Vincent Lopes-Vicente</name>


### PR DESCRIPTION
## Problem

`Action/ReCaptchaAction::checkCaptcha()` uses `file_get_contents()` to call Google's siteverify endpoint. This fails silently on hosts where PHP-FPM has `allow_url_fopen=Off` (common on shared hosting, e.g. Infomaniak): the call returns `false`, `json_decode` returns `null`, and every user gets `Invalid captcha` on newsletter / register / contact forms.

Error captured via `error_get_last()`:
```
file_get_contents(https://...): Failed to open stream: no suitable wrapper could be found
```

## Changes

- Replace `file_get_contents` with cURL (connect 3s, total 5s, `RETURNTRANSFER`).
- Send params as POST body via `http_build_query` instead of concatenating into the URL. Side effects: special chars in `g-recaptcha-response` no longer break the query string, and the `secret` key no longer leaks into outbound access logs / proxy caches.
- Guard against missing `curl` extension with `function_exists('curl_init')` — falls back to `captchaVerified=false` instead of fatal.
- Guard response parsing: `is_string($response)` and `is_array($result)` before reading keys, so any network / Google failure keeps the original silent-reject behavior.
- Bump module version `4.0.3` → `4.0.4`.

Business logic untouched: still `success === true` AND (no score OR score > minScore).